### PR TITLE
Removing Careers Link

### DIFF
--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -58,9 +58,6 @@
                         @Html.ActionLink("Curriculum", "Curriculum")
                     </li>
                     <li>
-                        <a href="~/misc/bcca-instructor-job-description.pdf" target="_blank">Careers</a>
-                    </li>
-                    <li>
                         <a href="https://www.crowdrise.com/bcca" target="_blank">Donate</a>
                     </li>
                     <!--


### PR DESCRIPTION
Just in case we want it simply deleted (references: #8), I thought I'd go ahead and create a PR for it.